### PR TITLE
command for byteball: URI

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -11,7 +11,7 @@ exports.storage = 'sqlite';
 
 exports.hub = 'byteball.org/bb';
 exports.deviceName = 'Poll Bot';
-exports.permanent_pairing_secret = '0000';
+exports.permanent_pairing_secret = '*'; // allow any pairing secret
 exports.control_addresses = [];
 exports.payout_address = 'WHERE THE MONEY CAN BE SENT TO';
 

--- a/poll-bot.js
+++ b/poll-bot.js
@@ -22,8 +22,8 @@ function readListOfPolls(handleList){
 	});
 }
 
-function getListOfPollCommands(arrQuestions){
-	return arrQuestions.map(poll => {
+function getListOfPollCommands(arrPolls){
+	return arrPolls.map(poll => {
 		let i = poll.question.indexOf(')');
 		// use unit as a command if question contains closing parenthesis
 		let command = (i === -1) ? poll.question : 'poll-'+ poll.unit;
@@ -50,8 +50,8 @@ function sendListOfPolls(device_address){
 		delete assocPollByDeviceAddress[device_address];
 	}
 
-	readListOfPolls(arrQuestions => {
-		let arrCommands = getListOfPollCommands(arrQuestions);
+	readListOfPolls(arrPolls => {
+		let arrCommands = getListOfPollCommands(arrPolls);
 		device.sendMessageToDevice(device_address, 'text', 'Please select the poll you would like to vote on:\n\n'+arrCommands.join('\n'));
 	});
 }


### PR DESCRIPTION
* any pairing code is valid now (needed for `byteball:` URI to work).
* questions that contain closing parenthesis now get reference by unit (same way `byteball:` URI commands do). it fixes the "More than one poll with a question like this" issue if some whitelisted question starts with "11)" and another with "1)".
* moved every choice to new line (visually better to understand with longer choices where one choice starts and other ends).
* added dash (-) in front of questions/choices (visually better to understand where one question/choice starts and other ends).
* added possibility to go back to whitelisted polls list.
* fixed a bug, which remembered last poll even if user was back in polls list.
* fixed a bug, which enabled to search with LIKE `%string%` if user entered `%string`.
* stats will now show 0 for choices that nobody has picked yet.
* added address count to stats.
* rewrote text handling and moved sending poll choices logic to separate function.
* any poll and its stats can be opened from `byteball:` URI now (pairing code as `poll-{unit}` or `stats-{unit}`), but poll bot will still show only whitelisted polls by default (if added from Bot Store).

For example, poll choices will be possible to open with this URI:
`byteball:AhMVGrYMCoeOHUaR9v/CZzTC34kScUeA4OBkRCxnWQM+@byteball.org/bb#poll-L5osgPIaknrgjsn3QBZC7TeF9PE2it5Cr3YiuUy28kY=`
and stats will be possible to open with this URI:
`byteball:AhMVGrYMCoeOHUaR9v/CZzTC34kScUeA4OBkRCxnWQM+@byteball.org/bb#stats-L5osgPIaknrgjsn3QBZC7TeF9PE2it5Cr3YiuUy28kY=`